### PR TITLE
Limit allowed pytorch versions to supported range

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: "b254b3b1bdb0d36ea83b34993d5de6d5ca3ab89a93e759d49e7a62307cad694c"
 
 build:
-  number: 3
+  number: 4
   # The upstream package does not support Windows.
   skip: True  # [win]
 
@@ -40,6 +40,7 @@ requirements:
     - packaging
   run_constrained:
     - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx]
+    - pytorch >=1.4,<1.7
 
 test:
   imports:


### PR DESCRIPTION
The range was determined with manual testing as the CoreMLTools docs don't give a lower bound, and appear to have an overly conservative upper bound.